### PR TITLE
Fix typo in DO_REGION variable

### DIFF
--- a/docs/03-compute-resources.md
+++ b/docs/03-compute-resources.md
@@ -11,7 +11,7 @@ VPC_ID=$(doctl vpcs create \
   --description kubernetes-the-hard-way \
   --ip-range 10.0.0.0/16 \
   --name kubernetes \
-  --region ${D0_REGION}
+  --region ${DO_REGION}
   --output json | jq -r '.[].id')
 ```
 


### PR DESCRIPTION
Fix typo in DO_REGION, which used the 0 (zero) character instead of O.